### PR TITLE
Check whether module exists before resolving

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -160,7 +160,7 @@ function makeResolver(targetDir, externalNames, alias) {
   for (const name of externalNames) {
     const modules = resolveModule(name, targetDir, alias);
     externals.push(
-      ...modules.map((m) => ({
+      ...modules.filter(m => existsSync(m.path)).map((m) => ({
         ...m,
         path: realpathSync(m.path),
       }))


### PR DESCRIPTION
Fixes https://github.com/FlorianRappl/parcel-plugin-externals/issues/24: Check whether the module path exists before resolving the path